### PR TITLE
added max_time to calibration settings

### DIFF
--- a/aixcalibuha/calibration/calibrator.py
+++ b/aixcalibuha/calibration/calibrator.py
@@ -13,7 +13,7 @@ import numpy as np
 import pandas as pd
 from ebcpy import data_types, Optimizer
 from ebcpy.simulationapi import SimulationAPI
-from aixcalibuha.utils import visualizer, MaxIterationsReached
+from aixcalibuha.utils import visualizer, MaxIterationsReached, MaxTimeReached
 from aixcalibuha import CalibrationClass, Goals, TunerParas
 
 
@@ -113,6 +113,7 @@ class Calibrator(Optimizer):
         self.perform_square_deviation = kwargs.pop("square_deviation", False)
         self.result_path = kwargs.pop('result_path', None)
         self.max_itercount = kwargs.pop('max_itercount', np.inf)
+        self.max_time = kwargs.pop('max_time', np.inf)
         self.at_calibration = True  # Boolean to indicate if validating or calibrating
         # Extract kwargs for the visualizer
         visualizer_kwargs = {
@@ -179,6 +180,21 @@ class Calibrator(Optimizer):
         self.logger.log("Setting output_interval of simulation according "
                         f"to measurement target data frequency: {mean_freq}")
         self.sim_api.sim_setup.output_interval = mean_freq
+        self.start_time = time.perf_counter()
+        
+    def _check_for_termination(self):
+        if self._counter >= self.max_itercount:
+            raise MaxIterationsReached(
+                "Terminating calibration as the maximum number "
+                f"of iterations {self.max_itercount} has been reached."
+            )
+            
+        if time.perf_counter() - self.start_time > self.max_time:
+            raise MaxTimeReached(
+                f"Terminating calibration as the maximum time of {self.max_time}s has been "
+                f"reached"
+            )
+        
 
     def obj(self, xk, *args):
         """
@@ -249,7 +265,8 @@ class Calibrator(Optimizer):
             counter=self._counter,
             results=sim_target_data
         )
-
+        self._check_for_termination()
+        
         return total_res, unweighted_objective
 
     def mp_obj(self, x, *args):
@@ -314,7 +331,8 @@ class Calibrator(Optimizer):
             )
             # Add single objective to objective list of total Population
             total_res_list[idx] = total_res
-
+        self._check_for_termination()
+        
         return total_res_list
 
     def _kpi_and_logging_calculation(self, *, xk_descaled, counter, results):
@@ -367,12 +385,6 @@ class Calibrator(Optimizer):
                 "Penaltyfactor": penalty
             }
 
-        if counter >= self.max_itercount:
-            raise MaxIterationsReached(
-                "Terminating calibration as the maximum number "
-                f"of iterations {self.max_itercount} has been reached."
-            )
-
         return total_res, unweighted_objective
 
     def calibrate(self, framework, method=None, **kwargs) -> dict:
@@ -408,7 +420,7 @@ class Calibrator(Optimizer):
                 method=method,
                 n_cpu=self.sim_api.n_cpu,
                 **kwargs)
-        except MaxIterationsReached as err:
+        except (MaxIterationsReached, MaxTimeReached) as err:
             self.logger.log(msg=str(err), level=logging.WARNING)
         t_cal_stop = time.time()
         t_cal = t_cal_stop - t_cal_start
@@ -560,7 +572,7 @@ class Calibrator(Optimizer):
         See ebcpy.optimization.Optimizer._handle_error for more info.
         """
         # This error is our own, we handle it in the calibrate() function
-        if isinstance(error, MaxIterationsReached):
+        if isinstance(error, (MaxIterationsReached, MaxTimeReached)):
             raise error
         self.logger.save_calibration_result(best_iterate=self._current_best_iterate,
                                             model_name=self.sim_api.model_name,

--- a/aixcalibuha/calibration/calibrator.py
+++ b/aixcalibuha/calibration/calibrator.py
@@ -83,6 +83,9 @@ class Calibrator(Optimizer):
         Maximum number of iterations of calibration.
         This may be useful to explicitly limit the calibration
         time.
+    :keyword int max_time":
+        Deault is Infinity.
+        Maximum time in seconds, after which the calibration is stopped. Useful to explicitly limit the calibration time.
     :keyword str plot_file_type:
         File ending of created plots.
         Any supported option in matplotlib, e.g. svg, png, pdf ...
@@ -191,7 +194,7 @@ class Calibrator(Optimizer):
             
         if time.perf_counter() - self.start_time > self.max_time:
             raise MaxTimeReached(
-                f"Terminating calibration as the maximum time of {self.max_time}s has been "
+                f"Terminating calibration as the maximum time of {self.max_time} s has been "
                 f"reached"
             )
         

--- a/aixcalibuha/utils/__init__.py
+++ b/aixcalibuha/utils/__init__.py
@@ -30,3 +30,9 @@ class MaxIterationsReached(Exception):
     ends because the maximum number of
     allowed iterations is reached.
     """
+    
+class MaxTimeReached(Exception):
+    """
+    Exception raised for when the calibration
+    ends because the maximum calibration time is reached.
+    """


### PR DESCRIPTION
Added functionality to set a maximum calibration time. Added general check for max_iteration and max_time and changed place of that, so that when using multiprocessing a termination is only done after the results of one multiprocessing round are evaluated, to not unnecessarily ignore finished results.

Closes #55 
